### PR TITLE
Make EpochTracker::Window() take a reference.

### DIFF
--- a/epoch_tracker/epoch_tracker.cc
+++ b/epoch_tracker/epoch_tracker.cc
@@ -584,7 +584,7 @@ void EpochTracker::GetPulseCorrelations(float window_dur, float peak_thresh) {
 }
 
 
-void EpochTracker::Window(const std::vector<float> input, int32_t offset, size_t size,
+void EpochTracker::Window(const std::vector<float>& input, int32_t offset, size_t size,
                           float* output) {
   if (size != window_.size()) {
     window_.resize(size);

--- a/epoch_tracker/epoch_tracker.h
+++ b/epoch_tracker/epoch_tracker.h
@@ -199,7 +199,7 @@ class EpochTracker {
   // Apply a Hann weighting to the signal in input starting at
   // sample index offset.  The window will contain size samples, and
   // the windowed signal is placed in output.
-  void Window(const std::vector<float> input, int32_t offset, size_t size,
+  void Window(const std::vector<float>& input, int32_t offset, size_t size,
               float* output);
 
   // Computes signal polarity (-1 for negative, +1 for


### PR DESCRIPTION
When running the program, I noticed it was taking a very long time – upon looking in a profiler it was clear it was allocating and deallocating a large amount of memory constantly.

`EpochTracker::Window` was taking a const `std::vector` by value (thereby copying all of its elements). I've changed it to take it by reference, removing unnecessary copies and making the whole program much, _much_ quicker.