### PR TITLE
Give access of inner computation steps to class user

### DIFF
--- a/epoch_tracker/epoch_tracker.h
+++ b/epoch_tracker/epoch_tracker.h
@@ -235,6 +235,24 @@ class EpochTracker {
   // internal storage, pending retrieval by other methods.
   bool TrackEpochs(void);
 
+  // Create a lattice of glottal period hypotheses in preparation for
+  // dynamic programming.  This fills out most of the data fields in
+  // resid_peaks_. This must be called after ComputeFeatures.
+  void CreatePeriodLattice(void);
+
+  // Apply the Viterbi dynamic programming algorithm to find the best
+  // path through the period hypothesis lattice created by
+  // CreatePeriodLattice.  The backpointers and cumulative scores are
+  // left in the relevant fields in resid_peaks_.
+  void DoDynamicProgramming(void);
+
+  // Backtrack through the best pointers in the period hypothesis
+  // lattice created by CreatePeriodLattice and processed by
+  // DoDynamicProgramming.  The estimated GCI locations
+  // (epochs) and the corresponding F0 and voicing-states are placed
+  // in the output_ array pending retrieval using other methods.
+  bool BacktrackAndSaveOutput(void);
+
   // Resample the per-period F0 and correlation data that results from
   // the tracker to a periodic signal at an interval of
   // resample_interval seconds.  Samples returned are those nearest in
@@ -304,25 +322,6 @@ class EpochTracker {
   // locations and the full NCCF are saved in the corresponding
   // elements of the resid_peaks_ array of structures.
   void GetPulseCorrelations(float window_dur, float peak_thresh);
-
- public:
-  // Create a lattice of glottal period hypotheses in preparation for
-  // dynamic programming.  This fills out most of the data fields in
-  // resid_peaks_. This must be called after ComputeFeatures.
-  void CreatePeriodLattice(void);
-
-  // Apply the Viterbi dynamic programming algorithm to find the best
-  // path through the period hypothesis lattice created by
-  // CreatePeriodLattice.  The backpointers and cumulative scores are
-  // left in the relevant fields in resid_peaks_.
-  void DoDynamicProgramming(void);
-
-  // Backtrack through the best pointers in the period hypothesis
-  // lattice created by CreatePeriodLattice and processed by
-  // DoDynamicProgramming.  The estimated GCI locations
-  // (epochs) and the corresponding F0 and voicing-states are placed
-  // in the output_ array pending retrieval using other methods.
-  bool BacktrackAndSaveOutput(void);
 
 
  private:

--- a/epoch_tracker/epoch_tracker.h
+++ b/epoch_tracker/epoch_tracker.h
@@ -305,6 +305,7 @@ class EpochTracker {
   // elements of the resid_peaks_ array of structures.
   void GetPulseCorrelations(float window_dur, float peak_thresh);
 
+ public:
   // Create a lattice of glottal period hypotheses in preparation for
   // dynamic programming.  This fills out most of the data fields in
   // resid_peaks_. This must be called after ComputeFeatures.


### PR DESCRIPTION
EpochTracker::TrackEpochs() might fail or take too long without the ability to the class user to get feedback.
Putting   CreatePeriodLattice(), DoDynamicProgramming() and BacktrackAndSaveOutput() in public allows the class user to decompose the usage of TrackEpochs, track errors and give a bit of computation progress to the end-user.
