### PR TITLE
Fix segfault when no residual peaks are found

### DIFF
--- a/epoch_tracker/epoch_tracker.cc
+++ b/epoch_tracker/epoch_tracker.cc
@@ -1020,6 +1020,10 @@ void EpochTracker::DoDynamicProgramming(void) {
 bool EpochTracker::BacktrackAndSaveOutput(void) {
   //  Now find the best period hypothesis at the end of the signal,
   //  and backtrack from there.
+  if (resid_peaks_.empty()) {
+      fprintf(stderr, "No residual peaks found\n");
+      return false;
+  }
   float min_cost = 1.0e30;
   int32_t min_index = 0;
   // First, find a terminal peak which is the end of more than one


### PR DESCRIPTION
My reproduction scenario is feeding a window full of zeros to EpochTracker. Not sure if it can happen in any other cases.

empty `resid_peaks_` gives an underflow and segfault in `BacktrackAndSaveOutput`.